### PR TITLE
Fix waiting thread hanging when producer throws

### DIFF
--- a/FastAtomicLazy.Benchmarks/FastLazyBenchmarks.cs
+++ b/FastAtomicLazy.Benchmarks/FastLazyBenchmarks.cs
@@ -51,7 +51,7 @@ namespace FastAtomicLazy.Benchmarks
         }
 
         [Benchmark]
-        public void Factory()
+        public void ProducerLazy()
         {
             var lazy = new FastLazy<int>(() => new Random().Next());
             var _ = lazy.Value;

--- a/FastAtomicLazy.Benchmarks/FastLazyBenchmarks.cs
+++ b/FastAtomicLazy.Benchmarks/FastLazyBenchmarks.cs
@@ -49,5 +49,12 @@ namespace FastAtomicLazy.Benchmarks
         {
             return _readAndExecuteSafeLazy.Value;
         }
+
+        [Benchmark]
+        public void Factory()
+        {
+            var lazy = new FastLazy<int>(() => new Random().Next());
+            var _ = lazy.Value;
+        }
     }
 }

--- a/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
+++ b/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
@@ -108,7 +108,7 @@ namespace FastAtomicLazy.Tests
         public void FastLazy_AllThreads_ShouldThrowException_WhenFactoryThrowsException()
         {
             var lazy = new FastLazy<string>(() => throw new Exception("Factory exception"));
-            var result = Parallel.For(0, Environment.ProcessorCount, i =>
+            var result = Parallel.For(0, 10, i =>
             {
                 Assert.Throws<Exception>(() => _ = lazy.Value);
             });

--- a/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
+++ b/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
@@ -112,7 +112,8 @@ namespace FastAtomicLazy.Tests
             {
                 Assert.Throws<Exception>(() => _ = lazy.Value);
             });
-            SpinWait.SpinUntil(() => result.IsCompleted);
+            
+            Assert.True(result.IsCompleted);
         }
     }
 }

--- a/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
+++ b/FastAtomicLazy.Tests/FastAtomicLazySpecs.cs
@@ -103,5 +103,16 @@ namespace FastAtomicLazy.Tests
             Assert.Equal(1000, values.Count);
             Assert.Equal(1, attempts);
         }
+        
+        [Fact]
+        public void FastLazy_AllThreads_ShouldThrowException_WhenFactoryThrowsException()
+        {
+            var lazy = new FastLazy<string>(() => throw new Exception("Factory exception"));
+            var result = Parallel.For(0, Environment.ProcessorCount, i =>
+            {
+                Assert.Throws<Exception>(() => _ = lazy.Value);
+            });
+            SpinWait.SpinUntil(() => result.IsCompleted);
+        }
     }
 }


### PR DESCRIPTION
Fixes #12 

## Changes

When producer throws all waiting threads throws too. I don't see any performance degradation in my changes. I added new benchmark for producer function and its show the same performance

## Checklist

* [x] This change follows the [Akka.NET API Compatibility Guidelines](https://getakka.net/community/contributing/api-changes-compatibility.html).
* [x] This change follows the [Akka.NET Wire Compatibility Guidelines](https://getakka.net/community/contributing/wire-compatibility.html).
* [x] I have [reviewed my own pull request](https://getakka.net/community/contributing/index.html#review-your-own-pull-requests).

### Latest `dev` Benchmarks 

|                           Method |          Mean |      Error |     StdDev |  Gen 0 | Allocated |
|--------------------------------- |--------------:|-----------:|-----------:|-------:|----------:|
|                     ReadFastLazy |     1.0343 ns |  0.0036 ns |  0.0032 ns |      - |         - |
|            ReadLazyNotThreadSafe |     0.1644 ns |  0.0042 ns |  0.0037 ns |      - |         - |
|    ReadLazyPublishOnlyThreadSafe |     0.3208 ns |  0.0037 ns |  0.0031 ns |      - |         - |
| ReadLazyReadAndExecuteThreadSafe |     0.0000 ns |  0.0000 ns |  0.0000 ns |      - |         - |
|                          Factory | 1,563.2363 ns | 14.5899 ns | 13.6474 ns | 0.1488 |     312 B |

### This PR's Benchmarks

|                           Method |          Mean |     Error |    StdDev |  Gen 0 | Allocated |
|--------------------------------- |--------------:|----------:|----------:|-------:|----------:|
|                     ReadFastLazy |     1.1957 ns | 0.0038 ns | 0.0034 ns |      - |         - |
|            ReadLazyNotThreadSafe |     0.0000 ns | 0.0000 ns | 0.0000 ns |      - |         - |
|    ReadLazyPublishOnlyThreadSafe |     0.2481 ns | 0.0024 ns | 0.0020 ns |      - |         - |
| ReadLazyReadAndExecuteThreadSafe |     0.0000 ns | 0.0000 ns | 0.0000 ns |      - |         - |
|                     ProducerLazy | 1,577.2046 ns | 1.8810 ns | 1.7595 ns | 0.1526 |     320 B |